### PR TITLE
Add shell v44 as supported version, fix typo

### DIFF
--- a/pnhelper@m-weigand.github.com/extension.js
+++ b/pnhelper@m-weigand.github.com/extension.js
@@ -371,7 +371,7 @@ class Extension {
 		// use the new quicksettings from GNOME 0.43
 		// https://gjs.guide/extensions/topics/quick-settings.html#example-usage
 		//
-		let brightness_file "/sys/class/backlight/backlight_warm/brightness";
+		let brightness_file = "/sys/class/backlight/backlight_warm/brightness";
 		const file = Gio.file_new_for_path(brightness_file);
 		if (!file.query_exists(null)){
 			log("No warm backlight control found - will not add slider for that");

--- a/pnhelper@m-weigand.github.com/metadata.json
+++ b/pnhelper@m-weigand.github.com/metadata.json
@@ -3,6 +3,6 @@
     "name": "Pinenote Helper",
     "description": "Provides easy access to some PineNote-related functionality",
     "version": 1.2,
-    "shell-version": ["43", "45" ],
+    "shell-version": ["43", "44", "45" ],
     "url": "https://github.com/PNDeb/pinenote-gnome-extension"
 }


### PR DESCRIPTION
I can confirm that this works on the PineNote on debian testing.
fixes #2 .