### PR TITLE
Fix extension disable issues

### DIFF
--- a/pnhelper@m-weigand.github.com/ebc.js
+++ b/pnhelper@m-weigand.github.com/ebc.js
@@ -70,9 +70,10 @@ function ebc_subscribe_to_waveformchanged(func, widget){
 	function func_signal (connection, sender, path, iface, signal, params){
 		func(connection, sender, path, iface, signal, params, widget);
 	}
-	PnProxy.connectSignal(
+	const ebc_dbus = PnProxy.connectSignal(
 		"WaveformChanged", func_signal
 	);
+  return(ebc_dbus);
 }
 
 // the pinenote-dbus-service can emit a signal which indicates that a
@@ -81,7 +82,13 @@ function ebc_subscribe_to_requestperformancemode(func, widget){
 	function func_signal (connection, sender, path, iface, signal, params){
 		func(connection, sender, path, iface, signal, params, widget);
 	}
-	PnProxy.connectSignal(
+	const ebc_dbus = PnProxy.connectSignal(
 		"ReqQualityOrPerformance", func_signal
 	);
+  return(ebc_dbus);
+}
+
+//Disconnect from the dbus signal when the extension is stopped
+function ebc_unsubscribe(dbus_handler){
+  PnProxy.disconnectSignal(dbus_handler);
 }

--- a/pnhelper@m-weigand.github.com/extension.js
+++ b/pnhelper@m-weigand.github.com/extension.js
@@ -213,6 +213,8 @@ var PerformanceModeButton = GObject.registerClass(
 
 		this.panel_label = new St.Label({
 			text: label_text,
+			y_expand: true,
+            y_align: Clutter.ActorAlign.CENTER,
         });
 
         this.add_child(this.panel_label);
@@ -300,27 +302,123 @@ var PerformanceModeButton = GObject.registerClass(
     }
 });
 
+var WarmSlider = GObject.registerClass(
+	class FeatureSlider extends QuickSettings.QuickSlider {
+		_init() {
+			super._init({
+				icon_name: 'weather-clear-night-symbolic',
+			});
+
+			this.filepath = "/sys/class/backlight/backlight_warm/brightness";
+			this.max_filepath = "/sys/class/backlight/backlight_warm/max_brightness";
+
+			// set slider to current value
+			this.max_value = this._get_content(this.max_filepath);
+			let cur_value = this._get_content(this.filepath);
+
+			let cur_slider = cur_value / this.max_value;
+			log(`Current value: ${cur_value} - ${cur_slider}`);
+			this.slider.unblock_signal_handler(this._sliderChangedId);
+
+			this.slider.block_signal_handler(this._sliderChangedId);
+			this.slider.value = cur_slider;
+
+			this._sliderChangedId = this.slider.connect('notify::value',
+				this._onSliderChanged.bind(this));
+
+			this._onSettingsChanged();
+
+			// Set an accessible name for the slider
+			this.slider.accessible_name = "Warm Backlight Brightness";
+		}
+
+		_onSettingsChanged() {
+			// Prevent the slider from emitting a change signal while being updated
+			this.slider.block_signal_handler(this._sliderChangedId);
+			// this.slider.value = this._settings.get_uint('feature-range') / 100.0;
+			this.slider.unblock_signal_handler(this._sliderChangedId);
+		}
+
+		_write_to_sysfs_file(filename, value){
+			try {
+				// The process starts running immediately after this
+				// function is called. Any error thrown here will be a
+				// result of the process failing to start, not the success
+				// or failure of the process itself.
+				let proc = Gio.Subprocess.new(
+					// The program and command options are passed as a list
+					// of arguments
+					['/bin/sh', '-c', `echo ${value} > ` + filename],
+						// /sys/module/drm/parameters/debug'],
+
+					// The flags control what I/O pipes are opened and how they are directed
+					Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
+				);
+
+				// Once the process has started, you can end it with
+				// `force_exit()`
+				// proc.force_exit();
+			} catch (e) {
+				logError(e);
+			}
+		}
+
+		_get_content(sysfs_file){
+			// read current value
+			const file = Gio.File.new_for_path(sysfs_file);
+			const [, contents, etag] = file.load_contents(null);
+			const ByteArray = imports.byteArray;
+			const contentsString = ByteArray.toString(contents);
+
+			return contentsString.replace(/[\n\r]/g, '');
+		}
+
+		_onSliderChanged() {
+			// Assuming our GSettings holds values between 0..100, adjust
+			// for the slider taking values between 0..1
+			const percent = Math.floor(this.slider.value * 100);
+
+			let relative = this.slider.value;
+			const brightness = Math.round(relative * this._get_content(this.max_filepath));
+			// log(`brightness: ${brightness}`);
+			this._write_to_sysfs_file(this.filepath, brightness);
+		}
+});
+
+var QuickSettingsWarmSlider = GObject.registerClass(
+	class FeatureIndicator extends QuickSettings.SystemIndicator {
+		_init() {
+			super._init();
+
+			// Create the slider and associate it with the indicator, being sure to
+			// destroy it along with the indicator
+			this.quickSettingsItems.push(new WarmSlider);
+
+			this.connect('destroy', () => {
+				this.quickSettingsItems.forEach(item => item.destroy());
+			});
+
+			// Add the indicator to the panel
+			QuickSettingsMenu._indicators.add_child(this);
+
+			// Add the slider to the menu, this time passing `2` as the second
+			// argument to ensure the slider spans both columns of the menu
+			QuickSettingsMenu._addItems(this.quickSettingsItems, 2);
+
+			// Move the slider from the bottom to be with the cool light slider
+			for (const item of this.quickSettingsItems) {
+				QuickSettingsMenu.menu._grid.set_child_below_sibling(
+					item,
+					QuickSettingsMenu._brightness.quickSettingsItems[0]
+				);
+			}
+		}
+});
 
 class Extension {
     constructor() {
         this._indicator = null;
         this._indicator2 = null;
-
-		// the button widgets
-		this.bw_but_grayscale = new PopupMenu.PopupMenuItem(_('Grayscale Mode'));
-		this.bw_but_bw_dither = new PopupMenu.PopupMenuItem(_('BW+Dither Mode'));
-		this.bw_but_bw = new PopupMenu.PopupMenuItem(_('BW Mode'));
-		this.bw_but_du4 = new PopupMenu.PopupMenuItem(_('DU4 Mode'));
-
-        this.m_bw_slider = new PopupMenu.PopupBaseMenuItem({ activate: true });
-		this.mitem_bw_dither_invert = new PopupMenu.PopupMenuItem(_('BW Invert On'));
-
-
-		this.panel_label = new St.Label({
-			text: "DADA",
-            y_expand: true,
-            y_align: Clutter.ActorAlign.CENTER
-        });
 
 		const home = GLib.getenv("HOME");
 		const file = Gio.file_new_for_path(home + "/.config/pinenote/do_not_show_overview");
@@ -347,7 +445,6 @@ class Extension {
 		}
 
 		new_label += waveform.toString();
-
 		widget.set_text(new_label);
 	}
 
@@ -371,125 +468,6 @@ class Extension {
 			logError(e);
 		}
 	}
-
-    _add_warm_indicator_to_main_gnome_menu() {
-		// use the new quicksettings from GNOME 0.43
-		// https://gjs.guide/extensions/topics/quick-settings.html#example-usage
-		//
-		let brightness_file = "/sys/class/backlight/backlight_warm/brightness";
-		const file = Gio.file_new_for_path(brightness_file);
-		if (!file.query_exists(null)){
-			log("No warm backlight control found - will not add slider for that");
-			return;
-		}
-
-		const FeatureSlider = GObject.registerClass(
-		class FeatureSlider extends QuickSettings.QuickSlider {
-			_init() {
-				super._init({
-					icon_name: 'weather-clear-night-symbolic',
-				});
-
-				this.filepath = "/sys/class/backlight/backlight_warm/brightness";
-				this.max_filepath = "/sys/class/backlight/backlight_warm/max_brightness";
-
-				// set slider to current value
-				this.max_value = this._get_content(this.max_filepath);
-				let cur_value = this._get_content(this.filepath);
-
-				let cur_slider = cur_value / this.max_value;
-				log(`Current value: ${cur_value} - ${cur_slider}`);
-				this.slider.unblock_signal_handler(this._sliderChangedId);
-
-				this.slider.block_signal_handler(this._sliderChangedId);
-				this.slider.value = cur_slider;
-
-				this._sliderChangedId = this.slider.connect('notify::value',
-					this._onSliderChanged.bind(this));
-
-				this._onSettingsChanged();
-
-				// Set an accessible name for the slider
-				this.slider.accessible_name = "Warm Backlight Brightness";
-			}
-
-			_onSettingsChanged() {
-				// Prevent the slider from emitting a change signal while being updated
-				this.slider.block_signal_handler(this._sliderChangedId);
-				// this.slider.value = this._settings.get_uint('feature-range') / 100.0;
-				this.slider.unblock_signal_handler(this._sliderChangedId);
-			}
-
-			_write_to_sysfs_file(filename, value){
-				try {
-					// The process starts running immediately after this
-					// function is called. Any error thrown here will be a
-					// result of the process failing to start, not the success
-					// or failure of the process itself.
-					let proc = Gio.Subprocess.new(
-						// The program and command options are passed as a list
-						// of arguments
-						['/bin/sh', '-c', `echo ${value} > ` + filename],
-							// /sys/module/drm/parameters/debug'],
-
-						// The flags control what I/O pipes are opened and how they are directed
-						Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
-					);
-
-					// Once the process has started, you can end it with
-					// `force_exit()`
-					// proc.force_exit();
-				} catch (e) {
-					logError(e);
-				}
-			}
-
-			_get_content(sysfs_file){
-				// read current value
-				const file = Gio.File.new_for_path(sysfs_file);
-				const [, contents, etag] = file.load_contents(null);
-				const ByteArray = imports.byteArray;
-				const contentsString = ByteArray.toString(contents);
-
-				return contentsString.replace(/[\n\r]/g, '');
-			}
-
-			_onSliderChanged() {
-				// Assuming our GSettings holds values between 0..100, adjust
-				// for the slider taking values between 0..1
-				const percent = Math.floor(this.slider.value * 100);
-
-				let relative = this.slider.value;
-				const brightness = Math.round(relative * this._get_content(this.max_filepath));
-				// log(`brightness: ${brightness}`);
-				this._write_to_sysfs_file(this.filepath, brightness);
-			}
-		});
-
-		const FeatureIndicator = GObject.registerClass(
-		class FeatureIndicator extends QuickSettings.SystemIndicator {
-			_init() {
-				super._init();
-
-				// Create the slider and associate it with the indicator, being sure to
-				// destroy it along with the indicator
-				this.quickSettingsItems.push(new FeatureSlider());
-
-				this.connect('destroy', () => {
-					this.quickSettingsItems.forEach(item => item.destroy());
-				});
-
-				// Add the indicator to the panel
-				QuickSettingsMenu._indicators.add_child(this);
-
-				// Add the slider to the menu, this time passing `2` as the second
-				// argument to ensure the slider spans both columns of the menu
-				QuickSettingsMenu._addItems(this.quickSettingsItems, 2);
-			}
-		});
-		// initialize a new slider object
-		this._indicator2 = new FeatureIndicator();
-    }
 
 	_change_bw_mode(new_mode){
 
@@ -557,24 +535,28 @@ class Extension {
 		// add three buttons for grayscale, bw, bw+dithering modes
 
 		// 1
+		this.bw_but_grayscale = new PopupMenu.PopupMenuItem(_('Grayscale Mode'));
 		this.bw_but_grayscale.connect('activate', () => {
 			this._change_bw_mode(0);
 		});
 		this._indicator.menu.addMenuItem(this.bw_but_grayscale);
 
 		// 2
+		this.bw_but_bw_dither = new PopupMenu.PopupMenuItem(_('BW+Dither Mode'));
 		this.bw_but_bw_dither.connect('activate', () => {
 			this._change_bw_mode(1);
 		});
 		this._indicator.menu.addMenuItem(this.bw_but_bw_dither);
 
 		// 3
+		this.bw_but_bw = new PopupMenu.PopupMenuItem(_('BW Mode'));
 		this.bw_but_bw.connect('activate', () => {
 			this._change_bw_mode(2);
 		});
 		this._indicator.menu.addMenuItem(this.bw_but_bw);
 
 		// 4
+		this.bw_but_du4 = new PopupMenu.PopupMenuItem(_('DU4 Mode'));
 		this.bw_but_du4.connect('activate', () => {
 			this._change_bw_mode(3);
 		});
@@ -582,7 +564,7 @@ class Extension {
 	}
 
 	_add_bw_slider() {
-        // this.m_bw_slider = new PopupMenu.PopupBaseMenuItem({ activate: true });
+		this.m_bw_slider = new PopupMenu.PopupBaseMenuItem({ activate: true });
 		this._indicator.menu.addMenuItem(this.m_bw_slider);
 
         this._bw_slider = new Slider.Slider(0.5);
@@ -733,6 +715,7 @@ class Extension {
 	}
 
 	_add_dither_invert_button(){
+		this.mitem_bw_dither_invert = new PopupMenu.PopupMenuItem(_('BW Invert On'));
 		let filename = '/sys/module/rockchip_ebc/parameters/bw_dither_invert'
 		let bw_dither_invert = this._get_content(filename);
 
@@ -788,26 +771,26 @@ class Extension {
 		);
 	}
 
-	add_panel_label(){
-		this.panel_label = new St.Label({
-			text: "DADA",
-            y_expand: true,
-            y_align: Clutter.ActorAlign.CENTER,
-        });
-		Main.panel.addToStatusArea(
-			"Waveform Status Label",
-			this.panel_label,
-			-1,
-			'center'
-		);
-	}
+    add_warm_indicator_to_main_gnome_menu() {
+		// use the new quicksettings from GNOME 0.43
+		// https://gjs.guide/extensions/topics/quick-settings.html#example-usage
+		//
+		let brightness_file = "/sys/class/backlight/backlight_warm/brightness";
+		const file = Gio.file_new_for_path(brightness_file);
+		if (!file.query_exists(null)){
+			log("No warm backlight control found - will not add slider for that");
+			return;
+		}
+		// initialize a new slider object
+		this._indicator2 = new QuickSettingsWarmSlider;
+    }
 
     enable() {
         log(`enabling ${Me.metadata.name}`);
 
 		this.add_refresh_button();
 		this.add_performance_mode_button();
-		// this.add_panel_label();
+		this.add_warm_indicator_to_main_gnome_menu();
 
 		// ////////////////////////////////////////////////////////////////////
 		this._topBox = new St.BoxLayout({ });
@@ -828,9 +811,14 @@ class Extension {
 
 		this._topBox.add(icon);
 
+		this.panel_label = new St.Label({
+			text: "DADA",
+            y_expand: true,
+            y_align: Clutter.ActorAlign.CENTER,
+        });
 		// Add the label
         // this._indicator.add_child(this.panel_label);
-		ebc.ebc_subscribe_to_waveformchanged(this.onWaveformChanged, this.panel_label);
+		this.dbus_proxy = ebc.ebc_subscribe_to_waveformchanged(this.onWaveformChanged, this.panel_label);
 
         this._topBox.add_child(this.panel_label);
         this._indicator.add_child(this._topBox);
@@ -853,12 +841,11 @@ class Extension {
 		});
 		this._indicator.menu.addMenuItem(item);
 
-		this._add_warm_indicator_to_main_gnome_menu();
 		this._add_bw_buttons();
 		this._add_bw_slider();
 		this._add_dither_invert_button();
 		this._add_auto_refresh_button();
-		// this._add_waveform_buttons();
+		this._add_waveform_buttons();
 		this._add_testing_button();
 		this._add_usb_mtp_gadget_buttons();
 
@@ -883,10 +870,19 @@ class Extension {
     disable() {
         log(`disabling ${Me.metadata.name}`);
 
+		ebc.ebc_unsubscribe(this.dbus_proxy)
+
         this._indicator.destroy();
         this._indicator = null;
-        this._m_warm_backlight_slider.destroy();
-        this._m_warm_backlight_slider = null;
+
+		this._trigger_refresh_button.destroy();
+		this._trigger_refresh_button = null;
+
+		this._performance_mode_button.destroy();
+		this._performance_mode_button = null;
+
+		this._indicator2.destroy();
+        this._indicator2 = null;
     }
 
 	rotate_screen(){


### PR DESCRIPTION
The extension was failing when disable was run causing it to become disabled by gnome extensions when I locked and then logged back in to my pinenote. Made some changes here to allow the extension to be properly disabled and enabled allowing for screen locking.

I also made a few small aesthetic changes, centering the Performance/Quality mode button in the title bar and moving the warm backlight slider to be between the volume and cool backlight slider to keep all the sliders in the quicksettings menu together

Fixes https://github.com/PNDeb/pinenote-gnome-extension/issues/9