### PR TITLE
Add Gsettings, No Off Screen button, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gschemas.compiled

--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,7 @@ The extended quick settings of GNOME:
 	mkdir build
 	git clone https://github.com/PNDeb/pinenote-gnome-extension.git
 	cd pinenote-gnome-extension
+	glib-compile-schemas pnhelper@m-weigand.github.com/schemas
 	dpkg-buildpackage -us -uc
 
 ## Testing under wayland

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 
 mkdir -p $HOME/.local/share/gnome-shell/extensions
+glib-compile-schemas pnhelper@m-weigand.github.com/schemas
 rsync -avh pnhelper@m-weigand.github.com/ $HOME/.local/share/gnome-shell/extensions/pnhelper@m-weigand.github.com/

--- a/pnhelper@m-weigand.github.com/ebc.js
+++ b/pnhelper@m-weigand.github.com/ebc.js
@@ -100,7 +100,7 @@ export function ebc_subscribe_to_waveformchanged(func, widget){
 
 // the pinenote-dbus-service can emit a signal which indicates that a
 // performance-mode-change was requested
-export function ebc_subscribe_to_requestperformancemode(func, widget){
+export function ebc_subscribe_to_requestedqualityorperformancemode(func, widget){
     function func_signal (connection, sender, path, iface, signal, params){
         func(connection, sender, path, iface, signal, params, widget);
     }

--- a/pnhelper@m-weigand.github.com/metadata.json
+++ b/pnhelper@m-weigand.github.com/metadata.json
@@ -4,5 +4,6 @@
     "description": "Provides easy access to some PineNote-related functionality",
     "version": 1.7,
     "shell-version": ["46", "47" ],
-    "url": "https://github.com/PNDeb/pinenote-gnome-extension"
+    "url": "https://github.com/PNDeb/pinenote-gnome-extension",
+    "settings-schema": "org.gnome.shell.extensions.pnhelper"
 }

--- a/pnhelper@m-weigand.github.com/schemas/org.gnome.shell.extensions.pnhelper.gschema.xml
+++ b/pnhelper@m-weigand.github.com/schemas/org.gnome.shell.extensions.pnhelper.gschema.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.pnhelper" path="/org/gnome/shell/extensions/pnhelper@m-weigand.github.com/">
+    <key name="auto-refresh" type="b">
+      <default>true</default>
+      <summary>Auto Refresh</summary>
+      <description>Whether the screen should be automatically refreshed regularly</description>
+    </key>
+    <key name="bw-mode" type="u">
+      <default>0</default>
+      <summary>BW Mode</summary>
+      <description>
+        Selects the mode driving the display. Possible values are:
+        0 = Grayscale mode
+        1 = BW+Dither mode
+        2 = Black &amp; White mode
+        3 = DU4 waveform mode
+      </description>
+    </key>
+    <key name="bw-dither-invert" type="b">
+      <default>false</default>
+      <summary>Invert BW Dithering</summary>
+      <description>Whether the screen should be inverted in Black and White Dithering mode</description>
+    </key>
+    <key name="no-off-screen" type="b">
+      <default>false</default>
+      <summary>No Off Screen</summary>
+      <description>Whether the current screen contents should be kept when entering suspend</description>
+    </key>
+    <key name="travel-mode" type="b">
+      <default>false</default>
+      <summary>Travel Mode</summary>
+      <description>Whether to suppress waking up the device when the cover is opened, so it doesn't drain the battery from shifting around in your bag</description>
+    </key>
+  </schema>
+</schemalist>

--- a/pnhelper@m-weigand.github.com/schemas/org.gnome.shell.extensions.pnhelper.gschema.xml
+++ b/pnhelper@m-weigand.github.com/schemas/org.gnome.shell.extensions.pnhelper.gschema.xml
@@ -17,6 +17,15 @@
         3 = DU4 waveform mode
       </description>
     </key>
+    <key name="quality-mode" type="b">
+      <default>true</default>
+      <summary>Quality Mode</summary>
+      <description>
+        Reduce visible artifacts as much as possible, with the downside of having bad latency.
+        This mode is intended for high-quality, low-speed, task such as reading or slow web browsing.
+        It is not intended for writing.
+      </description>
+    </key>
     <key name="bw-dither-invert" type="b">
       <default>false</default>
       <summary>Invert BW Dithering</summary>


### PR DESCRIPTION
~~*This PR builds on and should be reviewed and merged after #17/#18 and a rebase. Only 241b9f2 through 335f190 properly belong to this PR*~~ :heavy_check_mark: 

- Introduce Gsettings and perform the dance of updating the settings and letting them kick off the changed listener which in turn phones to the dbus service to actually apply it
  - Apply the settings if they differ from current state on enable
- Move code to update labels to separate functions
- Add check ornament to active bw mode button
- Make labels more clear about which state the device is currently in
- Add translation function `_()` around all label updates so the strings will not only be translated on initialization
  - As I just interpolated strings together, this might prevent automatic gathering of source translations, but I don't think that will happen too soon so I left it like that for now

Please note that this requires the changes from https://github.com/PNDeb/pinenote_dbus_service/pull/4 in order to work.

![image](https://github.com/user-attachments/assets/3f79452b-3311-42d8-bf1d-7ce3b5396f41)
