### PR TITLE
Block global.window_manager's confirm-display-change handlers  and call complete_display_change(true)

### DIFF
--- a/pnhelper@m-weigand.github.com/extension.js
+++ b/pnhelper@m-weigand.github.com/extension.js
@@ -416,11 +416,10 @@ var QuickSettingsWarmSlider = GObject.registerClass(
 
             // Create the slider and associate it with the indicator, being
             // sure to destroy it along with the indicator
-            this.quickSettingsItems.push(new WarmSlider());
+            let warm_slider = new WarmSlider();
+            this.quickSettingsItems.push(warm_slider);
 
-            this.connect('destroy', () => {
-                this.quickSettingsItems.forEach(item => item.destroy());
-            });
+            this.connect('destroy', () => warm_slider.destroy());
 
             // Add the indicator to the panel
             // TODO


### PR DESCRIPTION
This avoids having to ship a fork of gnome-shell to suppress the mode change confirmation popup.

Not tested.
